### PR TITLE
Get rid of implicit chunked/Tempfile bodies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.2.0
+
+* Remove forced `Transfer-Encoding: chunked` and the chunking body wrapper. It is actually a good idea to trust the app webserver to apply the transfer encoding as is appropriate. For the case when "you really have to", add a bypass in `RailsStreaming#zip_kit_stream` for forcing the chunking manually.
+
 ## 6.1.0
 
 * Add Sorbet `.rbi` for type hints and resolution. This should make developing with zip_kit more pleasant, and the library - more discoverable.

--- a/lib/zip_kit/output_enumerator.rb
+++ b/lib/zip_kit/output_enumerator.rb
@@ -114,7 +114,10 @@ class ZipKit::OutputEnumerator
       "Content-Encoding" => "identity",
       # Disable buffering for both nginx and Google Load Balancer, see
       # https://cloud.google.com/appengine/docs/flexible/how-requests-are-handled?tab=python#x-accel-buffering
-      "X-Accel-Buffering" => "no"
+      "X-Accel-Buffering" => "no",
+      # Set the correct content type. This should be overridden if you need to
+      # serve things such as EPubs and other derived ZIP formats.
+      "Content-Type" => "application/zip"
     }
   end
 

--- a/lib/zip_kit/rack_tempfile_body.rb
+++ b/lib/zip_kit/rack_tempfile_body.rb
@@ -1,7 +1,9 @@
 # frozen_string_literal: true
 
 # Contains a file handle which can be closed once the response finishes sending.
-# It supports `to_path` so that `Rack::Sendfile` can intercept it
+# It supports `to_path` so that `Rack::Sendfile` can intercept it.
+# This class is deprecated and is going to be removed in zip_kit 7.x
+# @api deprecated
 class ZipKit::RackTempfileBody
   TEMPFILE_NAME_PREFIX = "zip-tricks-tf-body-"
   attr_reader :tempfile

--- a/lib/zip_kit/rails_streaming.rb
+++ b/lib/zip_kit/rails_streaming.rb
@@ -7,14 +7,15 @@ module ZipKit::RailsStreaming
   # the Rails response stream is going to be closed automatically.
   # @param filename[String] name of the file for the Content-Disposition header
   # @param type[String] the content type (MIME type) of the archive being output
+  # @param use_chunked_transfer_encoding[Boolean] whether to forcibly encode output as chunked. Normally you should not need this.
   # @param zip_streamer_options[Hash] options that will be passed to the Streamer.
   #     See {ZipKit::Streamer#initialize} for the full list of options.
   # @yieldparam [ZipKit::Streamer] the streamer that can be written to
   # @return [ZipKit::OutputEnumerator] The output enumerator assigned to the response body
-  def zip_kit_stream(filename: "download.zip", type: "application/zip", **zip_streamer_options, &zip_streaming_blk)
+  def zip_kit_stream(filename: "download.zip", type: "application/zip", use_chunked_transfer_encoding: false, **zip_streamer_options, &zip_streaming_blk)
     # The output enumerator yields chunks of bytes generated from ZipKit. Instantiating it
     # first will also validate the Streamer options.
-    chunk_yielder = ZipKit::OutputEnumerator.new(**zip_streamer_options, &zip_streaming_blk)
+    output_enum = ZipKit::OutputEnumerator.new(**zip_streamer_options, &zip_streaming_blk)
 
     # We want some common headers for file sending. Rails will also set
     # self.sending_file = true for us when we call send_file_headers!
@@ -28,10 +29,16 @@ module ZipKit::RailsStreaming
       logger&.warn { "The downstream HTTP proxy/LB insists on HTTP/1.0 protocol, ZIP response will be buffered." }
     end
 
-    headers, rack_body = chunk_yielder.to_headers_and_rack_response_body(request.env)
+    headers = output_enum.streaming_http_headers
 
-    # Set the "particular" streaming headers
+    # In rare circumstances (such as the app using Rack::ContentLength - which should normally
+    # not be used allow the user to force the use of the chunked encoding
+    if use_chunked_transfer_encoding
+      output_enum = ZipKit::RackChunkedBody.new(output_enum)
+      headers["Transfer-Encoding"] = "chunked"
+    end
+
     response.headers.merge!(headers)
-    self.response_body = rack_body
+    self.response_body = output_enum
   end
 end

--- a/lib/zip_kit/streamer/heuristic.rb
+++ b/lib/zip_kit/streamer/heuristic.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "zlib"
+
 # Will be used to pick whether to store a file in the `stored` or
 # `deflated` mode, by compressing the first N bytes of the file and
 # comparing the stored and deflated data sizes. If deflate produces

--- a/lib/zip_kit/version.rb
+++ b/lib/zip_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipKit
-  VERSION = "6.1.0"
+  VERSION = "6.2.0"
 end

--- a/spec/zip_kit/rack_chunked_body_spec.rb
+++ b/spec/zip_kit/rack_chunked_body_spec.rb
@@ -1,0 +1,22 @@
+require "spec_helper"
+
+# This is a deprecated class and will be removed in zip_kit 7.x
+describe ZipKit::RackChunkedBody do
+  it "applies a chunked encoding" do
+    iterable = ["foo", "bar", "baz"].each
+    body = ZipKit::RackChunkedBody.new(iterable)
+
+    output_lines = []
+    body.each do |bytes|
+      output_lines << bytes
+    end
+
+    expect(output_lines).to eq([
+      "3\r\nfoo\r\n",
+      "3\r\nbar\r\n",
+      "3\r\nbaz\r\n",
+      "0\r\n",
+      "\r\n"
+    ])
+  end
+end

--- a/spec/zip_kit/rack_chunked_body_spec.rb
+++ b/spec/zip_kit/rack_chunked_body_spec.rb
@@ -1,6 +1,5 @@
 require "spec_helper"
 
-# This is a deprecated class and will be removed in zip_kit 7.x
 describe ZipKit::RackChunkedBody do
   it "applies a chunked encoding" do
     iterable = ["foo", "bar", "baz"].each

--- a/spec/zip_kit/rack_tempfile_body_spec.rb
+++ b/spec/zip_kit/rack_tempfile_body_spec.rb
@@ -1,0 +1,31 @@
+require "spec_helper"
+
+# This is a deprecated class and will be removed in zip_kit 7.x
+describe ZipKit::RackTempfileBody do
+  it "outputs a Tempfile and adds it to 'rack.tempfiles'" do
+    env = {}
+    iterable = ["foo", "bar", "baz"].each
+    body = ZipKit::RackTempfileBody.new(env, iterable)
+
+    expect(env["rack.tempfiles"]).to be_kind_of(Array)
+
+    tf_path = body.to_path
+
+    first_tempfile = env["rack.tempfiles"][0]
+    expect(tf_path).to eq(first_tempfile.path)
+
+    first_tempfile.rewind
+    expect(first_tempfile.read).to eq("foobarbaz")
+  end
+
+  it "outputs the data using #each" do
+    env = {}
+    iterable = ["foo", "bar", "baz"].each
+    body = ZipKit::RackTempfileBody.new(env, iterable)
+
+    readback = StringIO.new
+    readback.binmode
+    body.each { |chunk| readback << chunk }
+    expect(readback.string).to eq("foobarbaz")
+  end
+end

--- a/spec/zip_kit/zip_streaming_rack_app.ru
+++ b/spec/zip_kit/zip_streaming_rack_app.ru
@@ -1,0 +1,17 @@
+require_relative "../../lib/zip_kit"
+
+# Serve the test directory, where we are going to emit the ZIP file into.
+# Rack::File provides built-in support for Range: HTTP requests.
+zip_serving_app = ->(env) {
+  rng = Random.new(42)
+  enum = ZipKit::OutputEnumerator.new do |zip|
+    40.times do |n|
+      zip.write_file("file_#{n}.bin") do |sink|
+        sink << rng.bytes(1024 * 2)
+      end
+    end
+  end
+
+  [200, enum.streaming_http_headers, enum]
+}
+run zip_serving_app

--- a/spec/zip_kit/zip_streaming_via_rack_spec.rb
+++ b/spec/zip_kit/zip_streaming_via_rack_spec.rb
@@ -1,0 +1,47 @@
+require "spec_helper"
+require "net/http"
+
+describe "Streaming using OutputEnumerator and Rack" do
+  before :all do
+    rack_app = File.expand_path(__dir__ + "/zip_streaming_rack_app.ru")
+    # find a free tcp port
+    tcpserver = TCPServer.new("127.0.0.1", 0)
+    port = tcpserver.addr[1]
+    addr = tcpserver.addr[3]
+    tcpserver.close
+    @server_addr = "#{addr}:#{port}"
+    command = %W[bundle exec puma --bind tcp://#{@server_addr} #{rack_app}]
+    server = IO.popen(command, "r")
+    @server_pid = server.pid
+    # ensure server was sarted
+    expect(@server_pid).not_to be_nil
+    # wait for server to boot
+    expect { Timeout.timeout(10) { nil until server.gets =~ /Ctrl-C/ } }.not_to raise_error
+  end
+
+  after :all do
+    next if @server_pid.nil?
+    begin
+      Process.kill("TERM", @server_pid)
+    rescue Errno::ESRCH
+    end
+    begin
+      Process.wait(@server_pid)
+    rescue Errno::ECHILD
+    end
+  end
+
+  it "serves a ZIP correctly" do
+    url = "http://#{@server_addr}/temp.zip"
+    uri = URI.parse(url)
+
+    http = Net::HTTP.start(uri.hostname, uri.port)
+    request = Net::HTTP::Get.new(url)
+    response = http.request(request)
+
+    expect(response.header["Transfer-Encoding"]).to eq("chunked") # Puma should auto-add it
+    expect(response.header["Content-Length"]).to be_nil
+
+    expect(response.body.bytesize).to eq(87228)
+  end
+end


### PR DESCRIPTION
Following the discussion in https://github.com/julik/zip_kit/issues/2 - it is probably better to let the server decide to chunk or not chunk the response. On modern Rails, there is no Rack::ContentLength middleware in place.