### PR TITLE
Make RailsStreaming compatible with Live

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
-* Make `BlockWrite` respond to `write`
+## 6.2.1
+
+* Make `RailsStreaming` compatible with `ActionController::Live` (previously the response would hang)
+* Make `BlockWrite` respond to `write` in addition to `<<`
 
 ## 6.2.0
 

--- a/lib/zip_kit/version.rb
+++ b/lib/zip_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipKit
-  VERSION = "6.2.0"
+  VERSION = "6.2.1"
 end

--- a/rbi/zip_kit.rbi
+++ b/rbi/zip_kit.rbi
@@ -110,11 +110,9 @@ module ZipKit
   # all while preserving the correct offsets in the ZIP file structures. This allows usage
   # of `sendfile()` or socket `splice()` calls for "through" proxying.
   # 
-  # For stored entries, you need to know the CRC32 (as a uint) and the filesize upfront,
+  # If you want to avoid data descriptors - or write data bypassing the Streamer -
+  # you need to know the CRC32 (as a uint) and the filesize upfront,
   # before the writing of the entry body starts.
-  # 
-  # Any object that responds to `<<` can be used as the Streamer target - you can use
-  # a String, an Array, a Socket or a File, at your leisure.
   # 
   # ## Using the Streamer with runtime compression
   # 
@@ -2086,7 +2084,7 @@ end, T.untyped)
     # This is on the {ZipKit::OutputEnumerator} class since those headers are common, independent of the
     # particular response body getting served. You might want to override the headers with your particular
     # ones - for example, specific content types are needed for files which are, technically, ZIP files
-    # but are of a file format built "on top" of ZIPs - such as ODTs, the [Apple Wallet passes](https://developer.apple.com/documentation/walletpasses/building_a_pass)
+    # but are of a file format built "on top" of ZIPs - such as ODTs, [pkpass files](https://developer.apple.com/documentation/walletpasses/building_a_pass)
     # and ePubs.
     sig { returns(T::Hash[T.untyped, T.untyped]) }
     def self.streaming_http_headers; end

--- a/spec/zip_kit/zip_streaming_rack_app.ru
+++ b/spec/zip_kit/zip_streaming_rack_app.ru
@@ -1,4 +1,5 @@
 require_relative "../../lib/zip_kit"
+require "action_controller"
 
 # Serve the test directory, where we are going to emit the ZIP file into.
 # Rack::File provides built-in support for Range: HTTP requests.
@@ -14,4 +15,48 @@ zip_serving_app = ->(env) {
 
   [200, enum.streaming_http_headers, enum]
 }
-run zip_serving_app
+
+class ZipController < ActionController::Base
+  include ZipKit::RailsStreaming
+  def download
+    zip_kit_stream do |z|
+      rng = Random.new(42)
+      z.write_file("some.bin") do |io|
+        1024.times { io << rng.bytes(1024 * 64) }
+      end
+    end
+  end
+
+  def download_with_forced_chunking
+    zip_kit_stream(use_chunked_transfer_encoding: true) do |z|
+      rng = Random.new(42)
+      z.write_file("some.bin") do |io|
+        1024.times { io << rng.bytes(1024 * 64) }
+      end
+    end
+  end
+end
+
+class ZipControllerWithLive < ZipController
+  include ActionController::Live
+end
+
+map "/rack-app" do
+  run zip_serving_app
+end
+
+map "/rails-controller-implicit-chunking" do
+  run ZipController.action(:download)
+end
+
+map "/rails-controller-explicit-chunking" do
+  run ZipController.action(:download_with_forced_chunking)
+end
+
+map "/rails-controller-with-live-implicit-chunking" do
+  run ZipControllerWithLive.action(:download)
+end
+
+map "/rails-controller-with-live-explicit-chunking" do
+  run ZipControllerWithLive.action(:download_with_forced_chunking)
+end

--- a/spec/zip_kit/zip_streaming_via_rack_spec.rb
+++ b/spec/zip_kit/zip_streaming_via_rack_spec.rb
@@ -31,8 +31,8 @@ describe "Streaming using OutputEnumerator and Rack" do
     end
   end
 
-  it "serves a ZIP correctly" do
-    url = "http://#{@server_addr}/temp.zip"
+  it "serves a ZIP correctly via naked Rack" do
+    url = "http://#{@server_addr}/rack-app"
     uri = URI.parse(url)
 
     http = Net::HTTP.start(uri.hostname, uri.port)
@@ -43,5 +43,27 @@ describe "Streaming using OutputEnumerator and Rack" do
     expect(response.header["Content-Length"]).to be_nil
 
     expect(response.body.bytesize).to eq(87228)
+  end
+
+  paths = %w[
+    rails-controller-implicit-chunking
+    rails-controller-explicit-chunking
+    rails-controller-with-live-implicit-chunking
+    rails-controller-with-live-explicit-chunking
+  ]
+  paths.each do |path|
+    it "serves a ZIP correctly via /#{path}" do
+      url = "http://#{@server_addr}/#{path}"
+      uri = URI.parse(url)
+
+      http = Net::HTTP.start(uri.hostname, uri.port)
+      request = Net::HTTP::Get.new(url)
+      response = http.request(request)
+
+      expect(response.body.bytesize).to eq(67109038)
+
+      expect(response.header["Content-Length"]).to be_nil
+      expect(response.header["Transfer-Encoding"]).to eq("chunked") # Puma should auto-add it
+    end
   end
 end


### PR DESCRIPTION
ActionController::Live is a weird beast - but so be it. This makes `zip_kit_stream` work with controllers which use Live too - which requires a few tweaks.

This comes as a followup for  https://github.com/julik/zip_kit/issues/7 - it should be the responsibility of the library to ensure things still work for users.