### PR TITLE
Use lazy load hooks to safely integrate with ActionController

### DIFF
--- a/lib/zip_kit/railtie.rb
+++ b/lib/zip_kit/railtie.rb
@@ -2,6 +2,8 @@
 
 class ZipKit::Railtie < ::Rails::Railtie
   initializer "zip_kit.install_extensions" do |app|
-    ActionController::Base.include(ZipKit::RailsStreaming)
+    ActiveSupport.on_load(:action_controller) do
+      include(ZipKit::RailsStreaming)
+    end
   end
 end


### PR DESCRIPTION
This uses the ActiveSupport Lazy Load hooks callback to integrate ZipKit once ActionController is loaded. Previously, the Railtie would force ActionController to load which can cause problems.