### PR TITLE
Be more strict with frozen string literals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
-          ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: "Tests"
         run: bundle exec rspec --backtrace --fail-fast

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
 
 jobs:
   test_baseline_ruby:
-    name: Tests and Lint (Ruby 2.6)
+    name: "Tests (Ruby 2.6 baseline)"
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -20,11 +20,9 @@ jobs:
           bundler-cache: true
       - name: "Tests"
         run: bundle exec rspec --backtrace --fail-fast
-      - name: "Lint"
-        run: bundle exec rake standard
 
   test_newest_ruby:
-    name: Tests (Ruby 3.4)
+    name: "Tests (Ruby 3.4 with frozen string literals)"
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
@@ -38,3 +36,17 @@ jobs:
         env:
           RUBYOPT: "--enable=frozen-string-literal --debug=frozen-string-literal"
         run: "bundle exec rspec --backtrace --fail-fast"
+
+  lint_baseline_ruby: # We need to use syntax appropriate for the minimum supported Ruby version
+    name: Lint (Ruby 2.6 syntax)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+          bundler-cache: true
+      - name: "Lint"
+        run: bundle exec rake standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,23 +7,35 @@ env:
   BUNDLE_PATH: vendor/bundle
 
 jobs:
-  test:
-    name: Tests and Lint
+  test_baseline_ruby:
+    name: Tests and Lint (Ruby 2.6)
     runs-on: ubuntu-22.04
-    strategy:
-      matrix:
-        ruby:
-          - '2.6'
-          - '3.4'
     steps:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
+          ruby-version: '2.6'
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
       - name: "Tests"
         run: bundle exec rspec --backtrace --fail-fast
       - name: "Lint"
         run: bundle exec rake standard
+
+  test_newest_ruby:
+    name: Tests (Ruby 3.4)
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4.1'
+          bundler-cache: true
+      - name: "Tests" # Make the test suite hard-crash on frozen string literal violations
+        env:
+          RUBYOPT: "--enable=frozen-string-literal --debug=frozen-string-literal"
+        run: "bundle exec rspec --backtrace --fail-fast"

--- a/spec/zip_kit/block_deflate_spec.rb
+++ b/spec/zip_kit/block_deflate_spec.rb
@@ -100,7 +100,7 @@ describe ZipKit::BlockDeflate do
 
     it "does not write the end marker" do
       input_string = "compressible" * (1024 * 1024 * 10)
-      output_string = ""
+      output_string = +""
 
       described_class.deflate_in_blocks(StringIO.new(input_string), StringIO.new(output_string))
       expect(output_string).not_to be_empty
@@ -109,7 +109,7 @@ describe ZipKit::BlockDeflate do
 
     it "returns the number of bytes written" do
       input_string = "compressible" * (1024 * 1024 * 10)
-      output_string = ""
+      output_string = +""
 
       num_bytes = described_class.deflate_in_blocks(StringIO.new(input_string),
         StringIO.new(output_string))

--- a/spec/zip_kit/block_write_spec.rb
+++ b/spec/zip_kit/block_write_spec.rb
@@ -33,7 +33,7 @@ describe ZipKit::BlockWrite do
   end
 
   it "can write in all possible encodings, even if the strings are frozen" do
-    accum_string = ""
+    accum_string = +""
     adapter = described_class.new { |s| accum_string << s }
 
     adapter << "hello"
@@ -57,7 +57,7 @@ describe ZipKit::BlockWrite do
 
   it "does not change the encoding of source strings" do
     hello = "hello".encode(Encoding::UTF_8)
-    accum_string = "".force_encoding(Encoding::BINARY)
+    accum_string = (+"").force_encoding(Encoding::BINARY)
     adapter = described_class.new { |s| accum_string << s }
     adapter << hello
     expect(accum_string.encoding).to eq(Encoding::BINARY)

--- a/spec/zip_kit/file_reader_spec.rb
+++ b/spec/zip_kit/file_reader_spec.rb
@@ -138,7 +138,7 @@ describe ZipKit::FileReader do
 
       entry = entries.first
 
-      readback = ""
+      readback = +""
       reader = entry.extractor_from(zipfile)
       readback << reader.extract(10) until reader.eof?
 

--- a/spec/zip_kit/streamer_spec.rb
+++ b/spec/zip_kit/streamer_spec.rb
@@ -273,7 +273,7 @@ describe ZipKit::Streamer do
 
       # Rubyzip does not properly set the encoding of the entries it reads
       expect(second_entry.gp_flags).to eq(2_048)
-      expect(second_entry.name).to eq("второй-файл.bin".dup.force_encoding(Encoding::BINARY))
+      expect(second_entry.name).to eq((+"второй-файл.bin").force_encoding(Encoding::BINARY))
     end
   end
 

--- a/spec/zip_kit/streamer_spec.rb
+++ b/spec/zip_kit/streamer_spec.rb
@@ -72,7 +72,7 @@ describe ZipKit::Streamer do
     expect(fake_writer).to receive(:write_central_directory_file_header)
     expect(fake_writer).to receive(:write_end_of_central_directory)
 
-    described_class.open("", writer: fake_writer) do |zip|
+    described_class.open(+"", writer: fake_writer) do |zip|
       zip.write_deflated_file("stored.txt") do |sink|
         sink << File.read(__dir__ + "/war-and-peace.txt")
       end
@@ -273,7 +273,7 @@ describe ZipKit::Streamer do
 
       # Rubyzip does not properly set the encoding of the entries it reads
       expect(second_entry.gp_flags).to eq(2_048)
-      expect(second_entry.name).to eq("второй-файл.bin".force_encoding(Encoding::BINARY))
+      expect(second_entry.name).to eq("второй-файл.bin".dup.force_encoding(Encoding::BINARY))
     end
   end
 

--- a/spec/zip_kit/write_and_tell_spec.rb
+++ b/spec/zip_kit/write_and_tell_spec.rb
@@ -19,7 +19,7 @@ describe ZipKit::WriteAndTell do
       [12, 123, 0, 3].pack("C*")
     ]
 
-    buf = "превед".dup.force_encoding(Encoding::BINARY)
+    buf = (+"превед").force_encoding(Encoding::BINARY)
     writer = described_class.new(buf)
     strs.each { |s| writer << s }
     expect(writer.tell).to eq(79)
@@ -27,8 +27,8 @@ describe ZipKit::WriteAndTell do
   end
 
   it "does not change the encoding of the source string" do
-    str = "текста кусок".dup.force_encoding(Encoding::UTF_8)
-    buf = "превед".dup.force_encoding(Encoding::BINARY)
+    str = (+"текста кусок").force_encoding(Encoding::UTF_8)
+    buf = (+"превед").force_encoding(Encoding::BINARY)
     writer = described_class.new(buf)
     writer << str
     expect(buf.bytesize).to eq(35)

--- a/spec/zip_kit/write_and_tell_spec.rb
+++ b/spec/zip_kit/write_and_tell_spec.rb
@@ -2,7 +2,7 @@ require_relative "../spec_helper"
 
 describe ZipKit::WriteAndTell do
   it "maintains the count of bytes written" do
-    adapter = described_class.new("")
+    adapter = described_class.new(+"")
     expect(adapter.tell).to be_zero
 
     adapter << "hello"
@@ -19,7 +19,7 @@ describe ZipKit::WriteAndTell do
       [12, 123, 0, 3].pack("C*")
     ]
 
-    buf = "превед".force_encoding(Encoding::BINARY)
+    buf = "превед".dup.force_encoding(Encoding::BINARY)
     writer = described_class.new(buf)
     strs.each { |s| writer << s }
     expect(writer.tell).to eq(79)
@@ -27,8 +27,8 @@ describe ZipKit::WriteAndTell do
   end
 
   it "does not change the encoding of the source string" do
-    str = "текста кусок".force_encoding(Encoding::UTF_8)
-    buf = "превед".force_encoding(Encoding::BINARY)
+    str = "текста кусок".dup.force_encoding(Encoding::UTF_8)
+    buf = "превед".dup.force_encoding(Encoding::BINARY)
     writer = described_class.new(buf)
     writer << str
     expect(buf.bytesize).to eq(35)
@@ -60,7 +60,7 @@ describe ZipKit::WriteAndTell do
   end
 
   it "advances the internal pointer using advance_position_by" do
-    str = ""
+    str = +""
 
     adapter = described_class.new(str)
     expect(adapter.tell).to be_zero

--- a/spec/zip_kit/zip_writer_spec.rb
+++ b/spec/zip_kit/zip_writer_spec.rb
@@ -526,7 +526,7 @@ describe ZipKit::ZipWriter do
     end
 
     it "writes out the custom comment" do
-      buf = ""
+      buf = +""
       comment = "Ohai mate"
       subject.write_end_of_central_directory(io: buf,
         start_of_central_directory_location: 9_091_211,


### PR DESCRIPTION
There were no runtime warnings already, but this adds the config in CI to fail the test suite if frozen string mutations are attempted.