### PR TITLE
Ensure correct exception gets re-raised from `write_`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.3.2
+
+* Make sure `rollback!` correctly works with `write_file` and the original exception gets re-raised from `write_file` if
+  closing the current entry happens in `Writable#close`
+
 ## 6.3.1
 
 * Include `RailsStreaming` in a Rails loader callback, so that ActionController does not need to be in the namespace.

--- a/lib/zip_kit/streamer.rb
+++ b/lib/zip_kit/streamer.rb
@@ -8,7 +8,7 @@ require "set"
 # * `Array` - will contain binary strings
 # * `File` - data will be written to it as it gets generated
 # * `IO` (`Socket`, `StringIO`) - data gets written into it
-# , `IO`, `Socket` and even an unfrozen `String`...
+# * `String` - in binary encoding and unfrozen - also makes a decent output target
 #
 # or anything else that responds to `#<<` or `#write`.
 #

--- a/lib/zip_kit/streamer.rb
+++ b/lib/zip_kit/streamer.rb
@@ -565,10 +565,9 @@ class ZipKit::Streamer
     use_data_descriptor:,
     unix_permissions:
   )
-
     # Set state needed for proper rollback later. If write_local_file_header
     # does manage to write _some_ bytes, but fails later (we write in tiny bits sometimes)
-    # we should be able to create a filler from this offset on when we 
+    # we should be able to create a filler from this offset on when we
     @offset_before_last_local_file_header = @out.tell
     @remove_last_file_at_rollback = false
 

--- a/lib/zip_kit/streamer.rb
+++ b/lib/zip_kit/streamer.rb
@@ -5,8 +5,12 @@ require "set"
 # Is used to write ZIP archives without having to read them back or to overwrite
 # data. It outputs into any object that supports `<<` or `write`, namely:
 #
-# An `Array`, `File`, `IO`, `Socket` and even `String` all can be output destinations
-# for the `Streamer`.
+# * `Array` - will contain binary strings
+# * `File` - data will be written to it as it gets generated
+# * `IO` (`Socket`, `StringIO`) - data gets written into it
+# , `IO`, `Socket` and even an unfrozen `String`...
+#
+# or anything else that responds to `#<<` or `#write`.
 #
 # You can also combine output through the `Streamer` with direct output to the destination,
 # all while preserving the correct offsets in the ZIP file structures. This allows usage

--- a/lib/zip_kit/streamer.rb
+++ b/lib/zip_kit/streamer.rb
@@ -497,7 +497,7 @@ class ZipKit::Streamer
   #     end
   # @return [Integer] position in the output stream / ZIP archive
   def rollback!
-    @files.pop if @remove_last_file_at_rollback = false
+    @files.pop if @remove_last_file_at_rollback
 
     # Recreate the path set from remaining entries (PathSet does not support cheap deletes yet)
     @path_set.clear

--- a/lib/zip_kit/streamer.rb
+++ b/lib/zip_kit/streamer.rb
@@ -486,6 +486,10 @@ class ZipKit::Streamer
   # is likely already on the wire. However, excluding the entry from the central directory of the ZIP
   # file will allow better-behaved ZIP unarchivers to extract the entries which did store correctly,
   # provided they read the ZIP from the central directory and not straight-ahead.
+  # Rolling back does not perform any writes.
+  #
+  # `rollback!` gets called for you if an exception is raised inside the block of `write_file`,
+  # `write_deflated_file` and `write_stored_file`.
   #
   # @example
   #     zip.add_stored_entry(filename: "data.bin", size: 4.megabytes, crc32: the_crc)

--- a/lib/zip_kit/version.rb
+++ b/lib/zip_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipKit
-  VERSION = "6.3.1"
+  VERSION = "6.3.2"
 end

--- a/spec/zip_kit/file_reader_spec.rb
+++ b/spec/zip_kit/file_reader_spec.rb
@@ -93,7 +93,7 @@ describe ZipKit::FileReader do
         def write_end_of_central_directory(**kwargs)
           # Pretend there has to be more data
           kwargs[:central_directory_size] = kwargs[:central_directory_size] + 64
-          super(**kwargs)
+          super
         end
       end
 

--- a/spec/zip_kit/zip_writer_spec.rb
+++ b/spec/zip_kit/zip_writer_spec.rb
@@ -3,7 +3,7 @@ require_relative "../spec_helper"
 describe ZipKit::ZipWriter do
   class ByteReader < Struct.new(:io)
     def initialize(io)
-      super(io).tap { io.rewind }
+      super.tap { io.rewind }
     end
 
     def read_1b


### PR DESCRIPTION
Closes #19 and addresses the underlying cause of #15