### PR TITLE
Force strings to be treated as binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 6.3.3
 
-* Make sure `Writable#<<` converts the strings it is given into binary if they are not already in binary. This fixes an issue where `Heuristic` would suddenly start forwarding strings as-is to downstream callees.
+* Make sure `Writable#<<` converts the strings it is given into binary if they are not already in binary. This fixes an issue where `Heuristic` would suddenly start forwarding strings as-is to downstream callees. There is a lot of spots where the string-to-write gets forwarded and converting in every single one will be quite wasteful, but it can be handy to do in a few key places.
+* Make sure `WritableBuffer#<<` converts the strings it is given into binary if they are not already in binary. This helps prevent an issue where the receiving object the buffer flushes to is in a different encoding than binary (and all of our use cases assume bytes anyway, except for filenames).
 * When rescuing a failed `write_file`, differentiate between `#close`
   and `#release_resources_on_failure!`. Closing a Writable can still try
   to do things to the Streamer output, it can try to write to the destination

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 6.3.3
+
+* Make sure `Writable#<<` converts the strings it is given into binary if they are not already in binary. This fixes an issue where `Heuristic` would suddenly start forwarding strings as-is to downstream callees.
 * When rescuing a failed `write_file`, differentiate between `#close`
   and `#release_resources_on_failure!`. Closing a Writable can still try
   to do things to the Streamer output, it can try to write to the destination

--- a/lib/zip_kit/streamer/writable.rb
+++ b/lib/zip_kit/streamer/writable.rb
@@ -18,11 +18,11 @@ class ZipKit::Streamer::Writable
 
   # Writes the given data to the output stream
   #
-  # @param d[String] the binary string to write (part of the uncompressed file)
+  # @param string[String] the string to write (part of the uncompressed file)
   # @return [self]
-  def <<(d)
+  def <<(string)
     raise "Trying to write to a closed Writable" if @closed
-    @writer << d
+    @writer << string.b
     self
   end
 

--- a/lib/zip_kit/version.rb
+++ b/lib/zip_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipKit
-  VERSION = "6.3.2"
+  VERSION = "6.3.3"
 end

--- a/lib/zip_kit/write_buffer.rb
+++ b/lib/zip_kit/write_buffer.rb
@@ -42,14 +42,14 @@ class ZipKit::WriteBuffer
   # Appends the given data to the write buffer, and flushes the buffer into the
   # writable if the buffer size exceeds the `buffer_size` given at initialization
   #
-  # @param data[String] data to be written
+  # @param string[String] data to be written
   # @return self
-  def <<(data)
-    if data.bytesize >= @buffer_size
-      flush unless @buf.empty? # <- this is were we can output less than @buffer_size
-      @writable << data
+  def <<(string)
+    if string.bytesize >= @buffer_size
+      flush # <- this is were we can output less than @buffer_size
+      @writable << string.b
     else
-      @buf << data
+      @buf << string.b
       flush if @buf.bytesize >= @buffer_size
     end
     self

--- a/spec/zip_kit/streamer/heuristic_spec.rb
+++ b/spec/zip_kit/streamer/heuristic_spec.rb
@@ -1,11 +1,14 @@
 require_relative "../../spec_helper"
 
 describe ZipKit::Streamer::Heuristic do
-  it "does not allow non-binary encoded Strings to be passed downstream" do
+  it "does not raise with small UTF-8 strings getting passed" do
     output = StringIO.new
     streamer = ZipKit::Streamer.new(output)
-    
+
     subject = described_class.new(streamer, "somefile.bin")
-    ((64 * 1024) + 2).times { subject << "é" }
+    expect {
+      ((64 * 1024) + 2).times { subject << "é" }
+      subject.close
+    }.not_to raise_error
   end
 end

--- a/spec/zip_kit/streamer/heuristic_spec.rb
+++ b/spec/zip_kit/streamer/heuristic_spec.rb
@@ -1,0 +1,11 @@
+require_relative "../../spec_helper"
+
+describe ZipKit::Streamer::Heuristic do
+  it "does not allow non-binary encoded Strings to be passed downstream" do
+    output = StringIO.new
+    streamer = ZipKit::Streamer.new(output)
+    
+    subject = described_class.new(streamer, "somefile.bin")
+    ((64 * 1024) + 2).times { subject << "é" }
+  end
+end

--- a/spec/zip_kit/streamer/writable_spec.rb
+++ b/spec/zip_kit/streamer/writable_spec.rb
@@ -20,6 +20,19 @@ describe ZipKit::Streamer::Writable do
       subject.close
       expect { subject << "foo" }.to raise_error(/closed/)
     end
+
+    it "only passes binary strings to the target" do
+      fake_streamer = double
+      fake_deflater = Object.new
+      def fake_deflater.<<(data)
+        raise "data passed must be in binary" unless data.encoding == Encoding::BINARY
+      end
+
+      subject = described_class.new(fake_streamer, fake_deflater)
+      expect {
+        subject << "é"
+      }.not_to raise_error
+    end
   end
 
   describe "#close" do

--- a/spec/zip_kit/write_buffer_spec.rb
+++ b/spec/zip_kit/write_buffer_spec.rb
@@ -7,6 +7,17 @@ describe ZipKit::WriteBuffer do
     expect(adapter << "a").to eq(adapter)
   end
 
+  it "performs appends to the buffer in binary encoding only" do
+    # The WriteBuffer reuses strings, so for a good reproduction
+    # we need the sink to be something realistic
+    sink = "å".b
+    buffer = described_class.new(sink, 1)
+
+    expect {
+      2.times { buffer << "é".encode(Encoding::UTF_8) }
+    }.not_to raise_error
+  end
+
   it "appends the written strings in one go for the set buffer size" do
     sink = double("Writable")
 


### PR DESCRIPTION
In a few places strings in other encodings could slip through.

* Make sure `Writable#<<` converts the strings it is given into binary if they are not already in binary. This fixes an issue where `Heuristic` would suddenly start forwarding strings as-is to downstream callees. There is a lot of spots where the string-to-write gets forwarded and converting in every single one will be quite wasteful, but it can be handy to do in a few key places.

* Make sure `WritableBuffer#<<` converts the strings it is given into binary if they are not already in binary. This helps prevent an issue where the receiving object the buffer flushes to is in a different encoding than binary (and all of our use cases assume bytes anyway, except for filenames).

Fixes https://github.com/julik/zip_kit/issues/23