### PR TITLE
Fix rollback! on first entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.3.4
+
+* Fix a bug whereby `rollback!` would cause an exception without any entries having been written yet (rollback on first entry).
+
 ## 6.3.3
 
 * Make sure `Writable#<<` converts the strings it is given into binary if they are not already in binary. This fixes an issue where `Heuristic` would suddenly start forwarding strings as-is to downstream callees. There is a lot of spots where the string-to-write gets forwarded and converting in every single one will be quite wasteful, but it can be handy to do in a few key places.

--- a/lib/zip_kit/streamer.rb
+++ b/lib/zip_kit/streamer.rb
@@ -273,6 +273,11 @@ class ZipKit::Streamer
   #    output (using `IO.copy_stream` is a good approach).
   # @return [ZipKit::Streamer::Writable] without a block - the Writable sink which has to be closed manually
   def write_file(filename, modification_time: Time.now.utc, unix_permissions: nil, &blk)
+    # Reset rollback state when starting a new entry attempt, so that if this entry
+    # fails before writing a header, rollback! won't use stale values from a previous entry
+    @offset_before_last_local_file_header = nil
+    @remove_last_file_at_rollback = false
+
     writable = ZipKit::Streamer::Heuristic.new(self, filename, modification_time: modification_time, unix_permissions: unix_permissions)
     yield_or_return_writable(writable, &blk)
   end

--- a/lib/zip_kit/streamer.rb
+++ b/lib/zip_kit/streamer.rb
@@ -510,8 +510,13 @@ class ZipKit::Streamer
     end
 
     # Create filler for the truncated or unusable local file entry that did get written into the output
-    filler_size_bytes = @out.tell - @offset_before_last_local_file_header
-    @files << Filler.new(filler_size_bytes)
+    # Only create a filler if a local file header was actually written (indicated by
+    # @offset_before_last_local_file_header being set). If it's nil, no header was written,
+    # so there's nothing to create a filler for.
+    if @offset_before_last_local_file_header
+      filler_size_bytes = @out.tell - @offset_before_last_local_file_header
+      @files << Filler.new(filler_size_bytes)
+    end
 
     @out.tell
   end

--- a/lib/zip_kit/version.rb
+++ b/lib/zip_kit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module ZipKit
-  VERSION = "6.3.3"
+  VERSION = "6.3.4"
 end

--- a/rbi/zip_kit.rbi
+++ b/rbi/zip_kit.rbi
@@ -1,6 +1,6 @@
 # typed: strong
 module ZipKit
-  VERSION = T.let("6.3.3", T.untyped)
+  VERSION = T.let("6.3.4", T.untyped)
 
   class Railtie < Rails::Railtie
   end

--- a/spec/zip_kit/streamer_spec.rb
+++ b/spec/zip_kit/streamer_spec.rb
@@ -675,4 +675,34 @@ describe ZipKit::Streamer do
       zip.close
     }.not_to raise_error # Offset validation should pass
   end
+
+  it "handles rollback when first entry fails before header is written" do
+    # This test reproduces the issue described in https://github.com/julik/zip_kit/issues/26
+    # When the first entry fails to add (e.g., due to an invalid URL or other error
+    # before the local file header is written), rollback! should not fail with a TypeError.
+    # This can happen when using write_file with Heuristic, where an exception occurs
+    # in the block before the Heuristic decides which compression method to use and
+    # calls write_deflated_file/write_stored_file (which would set @offset_before_last_local_file_header).
+    zip = described_class.new(StringIO.new)
+
+    # Simulate a scenario where an exception occurs in the block passed to write_file
+    # before the Heuristic calls write_deflated_file or write_stored_file (which would
+    # set @offset_before_last_local_file_header). This happens when the exception
+    # occurs before close() is called on the Heuristic writable.
+    expect {
+      zip.write_file("test.txt") do |sink|
+        # Raise an error before any data is written, so the Heuristic hasn't decided
+        # which compression method to use yet, and no header has been written
+        raise "Invalid URL or other error"
+      end
+    }.to raise_error("Invalid URL or other error")
+
+    expect {
+      zip.rollback!
+    }.not_to raise_error
+
+    expect {
+      zip.close
+    }.not_to raise_error
+  end
 end


### PR DESCRIPTION
Closes #26

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes `rollback!` to handle failures before any local header is written and avoid stale state, adds specs, and bumps version to 6.3.4.
> 
> - **Streamer**:
>   - `write_file`: reset rollback state per entry to avoid stale offsets.
>   - `rollback!`: only add `Filler` when `@offset_before_last_local_file_header` is set.
> - **Tests**:
>   - Add specs covering rollback when the first or subsequent entry fails before header write and ensuring prior entries are preserved.
> - **Versioning**:
>   - Bump `VERSION` to `6.3.4`; update `CHANGELOG.md` and `rbi/zip_kit.rbi`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc9647f96001112b3acdb759f2305248fae2bfa6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->