### PR TITLE
Add a state machine to track the state of the ZIP

### DIFF
--- a/lib/zip_kit/streamer/state_machine.rb
+++ b/lib/zip_kit/streamer/state_machine.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+# Tracks the state of ZIP output to enforce valid call sequences.
+# States mirror the ZIP file structure: local headers, entry bodies,
+# data descriptors, central directory, and EOCD.
+class ZipKit::Streamer::StateMachine
+  INITIAL = :initial
+  LOCAL_HEADER = :local_header
+  ENTRY_BODY = :entry_body
+  DATA_DESCRIPTORS = :data_descriptors
+  CENTRAL_DIRECTORY = :central_directory
+  END_OF_CENTRAL_DIRECTORY = :end_of_central_directory
+
+  TRANSITIONS = {
+    INITIAL => [LOCAL_HEADER, CENTRAL_DIRECTORY],
+    LOCAL_HEADER => [ENTRY_BODY],
+    ENTRY_BODY => [DATA_DESCRIPTORS, LOCAL_HEADER, CENTRAL_DIRECTORY],
+    DATA_DESCRIPTORS => [LOCAL_HEADER, CENTRAL_DIRECTORY],
+    CENTRAL_DIRECTORY => [END_OF_CENTRAL_DIRECTORY],
+    END_OF_CENTRAL_DIRECTORY => []
+  }.freeze
+
+  attr_reader :state, :previous_state, :transition_offset
+  attr_reader :entry_offset, :current_entry
+
+  def initialize
+    @state = INITIAL
+    @previous_state = nil
+    @transition_offset = 0
+    @entry_offset = nil
+    @current_entry = nil
+  end
+
+  def transition!(to_state, offset)
+    unless TRANSITIONS[@state]&.include?(to_state)
+      raise ZipKit::Streamer::InvalidState,
+        "Cannot transition from #{@state} to #{to_state}. " \
+        "Valid next states: #{TRANSITIONS[@state].inspect}"
+    end
+
+    @previous_state = @state
+    @transition_offset = offset
+    @state = to_state
+  end
+
+  def begin_entry(entry, offset)
+    transition!(LOCAL_HEADER, offset)
+    @entry_offset = offset
+    @current_entry = entry
+  end
+
+  def begin_entry_body(offset)
+    transition!(ENTRY_BODY, offset)
+  end
+
+  def write_data_descriptor(offset)
+    transition!(DATA_DESCRIPTORS, offset)
+    @entry_offset = nil
+    @current_entry = nil
+  end
+
+  def begin_central_directory(offset)
+    transition!(CENTRAL_DIRECTORY, offset)
+    @entry_offset = nil
+    @current_entry = nil
+  end
+
+  def finalize(offset)
+    transition!(END_OF_CENTRAL_DIRECTORY, offset)
+  end
+
+  def rollback(current_offset)
+    unless @state == ENTRY_BODY || @state == LOCAL_HEADER
+      raise ZipKit::Streamer::InvalidState,
+        "Cannot rollback from #{@state}. Rollback is only valid during entry writing."
+    end
+
+    context = {
+      entry_offset: @entry_offset,
+      current_entry: @current_entry,
+      bytes_written: current_offset - @entry_offset
+    }
+
+    # Clear entry tracking, and transition to ENTRY_BODY
+    # (this allows starting new entries or closing the archive)
+    @previous_state = @state
+    @state = ENTRY_BODY
+    @transition_offset = current_offset
+    @entry_offset = nil
+    @current_entry = nil
+
+    context
+  end
+
+  # Query methods
+  def can_begin_entry?
+    TRANSITIONS[@state]&.include?(LOCAL_HEADER)
+  end
+
+  def can_write_body?
+    @state == ENTRY_BODY
+  end
+
+  def can_close_archive?
+    TRANSITIONS[@state]&.include?(CENTRAL_DIRECTORY)
+  end
+
+  def closed?
+    @state == END_OF_CENTRAL_DIRECTORY
+  end
+
+  def in_entry?
+    @state == LOCAL_HEADER || @state == ENTRY_BODY
+  end
+end

--- a/spec/zip_kit/streamer/state_machine_spec.rb
+++ b/spec/zip_kit/streamer/state_machine_spec.rb
@@ -1,0 +1,325 @@
+# frozen_string_literal: true
+
+require_relative "../../spec_helper"
+
+describe ZipKit::Streamer::StateMachine do
+  subject { described_class.new }
+
+  describe "initial state" do
+    it "starts in INITIAL state" do
+      expect(subject.state).to eq(:initial)
+      expect(subject.can_begin_entry?).to be true
+      expect(subject.can_close_archive?).to be true
+      expect(subject.closed?).to be false
+      expect(subject.in_entry?).to be false
+    end
+
+    it "has nil previous_state" do
+      expect(subject.previous_state).to be_nil
+    end
+
+    it "has zero transition_offset" do
+      expect(subject.transition_offset).to eq(0)
+    end
+  end
+
+  describe "#begin_entry" do
+    it "transitions to LOCAL_HEADER state" do
+      entry = double("Entry", filename: "test.txt")
+      subject.begin_entry(entry, 0)
+
+      expect(subject.state).to eq(:local_header)
+      expect(subject.previous_state).to eq(:initial)
+      expect(subject.entry_offset).to eq(0)
+      expect(subject.current_entry).to eq(entry)
+      expect(subject.in_entry?).to be true
+    end
+  end
+
+  describe "#begin_entry_body" do
+    it "transitions from LOCAL_HEADER to ENTRY_BODY" do
+      subject.begin_entry(double("Entry"), 0)
+      subject.begin_entry_body(50)
+
+      expect(subject.state).to eq(:entry_body)
+      expect(subject.previous_state).to eq(:local_header)
+      expect(subject.transition_offset).to eq(50)
+      expect(subject.can_write_body?).to be true
+    end
+  end
+
+  describe "full entry lifecycle with data descriptor" do
+    it "follows the complete lifecycle" do
+      entry = double("Entry", filename: "test.txt")
+
+      subject.begin_entry(entry, 0)
+      expect(subject.state).to eq(:local_header)
+      expect(subject.entry_offset).to eq(0)
+
+      subject.begin_entry_body(50)
+      expect(subject.state).to eq(:entry_body)
+      expect(subject.can_write_body?).to be true
+
+      subject.write_data_descriptor(150)
+      expect(subject.state).to eq(:data_descriptors)
+      expect(subject.entry_offset).to be_nil
+      expect(subject.current_entry).to be_nil
+      expect(subject.can_begin_entry?).to be true
+    end
+  end
+
+  describe "invalid transitions" do
+    it "prevents LOCAL_HEADER -> LOCAL_HEADER" do
+      subject.begin_entry(double("Entry"), 0)
+
+      expect { subject.begin_entry(double("Entry2"), 100) }
+        .to raise_error(ZipKit::Streamer::InvalidState, /Cannot transition/)
+    end
+
+    it "prevents INITIAL -> ENTRY_BODY" do
+      expect { subject.begin_entry_body(0) }
+        .to raise_error(ZipKit::Streamer::InvalidState, /Cannot transition/)
+    end
+
+    it "prevents INITIAL -> DATA_DESCRIPTORS" do
+      expect { subject.write_data_descriptor(0) }
+        .to raise_error(ZipKit::Streamer::InvalidState, /Cannot transition/)
+    end
+
+    it "prevents LOCAL_HEADER -> CENTRAL_DIRECTORY" do
+      subject.begin_entry(double("Entry"), 0)
+
+      expect { subject.begin_central_directory(50) }
+        .to raise_error(ZipKit::Streamer::InvalidState, /Cannot transition/)
+    end
+  end
+
+  describe "entries without data descriptors" do
+    it "allows ENTRY_BODY -> LOCAL_HEADER" do
+      subject.begin_entry(double("Entry1"), 0)
+      subject.begin_entry_body(50)
+
+      # Direct transition to next entry (no data descriptor)
+      subject.begin_entry(double("Entry2"), 100)
+      expect(subject.state).to eq(:local_header)
+    end
+
+    it "allows ENTRY_BODY -> CENTRAL_DIRECTORY" do
+      subject.begin_entry(double("Entry1"), 0)
+      subject.begin_entry_body(50)
+
+      subject.begin_central_directory(100)
+      expect(subject.state).to eq(:central_directory)
+    end
+  end
+
+  describe "DATA_DESCRIPTORS transitions" do
+    before do
+      subject.begin_entry(double("Entry1"), 0)
+      subject.begin_entry_body(50)
+      subject.write_data_descriptor(150)
+    end
+
+    it "allows DATA_DESCRIPTORS -> LOCAL_HEADER" do
+      subject.begin_entry(double("Entry2"), 150)
+      expect(subject.state).to eq(:local_header)
+    end
+
+    it "allows DATA_DESCRIPTORS -> CENTRAL_DIRECTORY" do
+      subject.begin_central_directory(150)
+      expect(subject.state).to eq(:central_directory)
+    end
+  end
+
+  describe "#rollback" do
+    it "raises when called from INITIAL" do
+      expect { subject.rollback(100) }
+        .to raise_error(ZipKit::Streamer::InvalidState, /only valid during entry writing/)
+    end
+
+    it "raises when called from DATA_DESCRIPTORS" do
+      subject.begin_entry(double("Entry"), 0)
+      subject.begin_entry_body(50)
+      subject.write_data_descriptor(150)
+
+      expect { subject.rollback(200) }
+        .to raise_error(ZipKit::Streamer::InvalidState, /only valid during entry writing/)
+    end
+
+    it "returns context and transitions to ENTRY_BODY from ENTRY_BODY" do
+      entry = double("Entry", filename: "fail.txt")
+      subject.begin_entry(entry, 42)
+      subject.begin_entry_body(100)
+
+      context = subject.rollback(250)
+
+      expect(context[:entry_offset]).to eq(42)
+      expect(context[:current_entry]).to eq(entry)
+      expect(context[:bytes_written]).to eq(208) # 250 - 42
+
+      # Transitions to entry_body (allows next entry or close)
+      expect(subject.state).to eq(:entry_body)
+      expect(subject.entry_offset).to be_nil
+      expect(subject.current_entry).to be_nil
+    end
+
+    it "returns context and transitions to ENTRY_BODY from LOCAL_HEADER" do
+      entry = double("Entry", filename: "fail.txt")
+      subject.begin_entry(entry, 42)
+      # Don't call begin_entry_body - simulates failure during header write
+
+      context = subject.rollback(60)
+
+      expect(context[:entry_offset]).to eq(42)
+      expect(context[:current_entry]).to eq(entry)
+      expect(context[:bytes_written]).to eq(18) # 60 - 42
+
+      # Transitions to entry_body (allows next entry or close)
+      expect(subject.state).to eq(:entry_body)
+      expect(subject.entry_offset).to be_nil
+      expect(subject.current_entry).to be_nil
+    end
+
+    it "allows beginning a new entry after rollback from ENTRY_BODY" do
+      subject.begin_entry(double("Entry1"), 0)
+      subject.begin_entry_body(50)
+      subject.rollback(100)
+
+      # Should be able to start a new entry
+      subject.begin_entry(double("Entry2"), 100)
+      expect(subject.state).to eq(:local_header)
+    end
+
+    it "allows beginning a new entry after rollback from LOCAL_HEADER" do
+      subject.begin_entry(double("Entry1"), 0)
+      subject.rollback(50)
+
+      # Should be able to start a new entry
+      subject.begin_entry(double("Entry2"), 50)
+      expect(subject.state).to eq(:local_header)
+    end
+
+    it "allows closing archive after rollback" do
+      subject.begin_entry(double("Entry1"), 0)
+      subject.begin_entry_body(50)
+      subject.rollback(100)
+
+      # Should be able to close archive
+      subject.begin_central_directory(100)
+      expect(subject.state).to eq(:central_directory)
+    end
+  end
+
+  describe "#finalize" do
+    it "transitions from CENTRAL_DIRECTORY to END_OF_CENTRAL_DIRECTORY" do
+      subject.begin_central_directory(0)
+      subject.finalize(100)
+
+      expect(subject.state).to eq(:end_of_central_directory)
+      expect(subject.closed?).to be true
+    end
+  end
+
+  describe "empty archive" do
+    it "allows INITIAL -> CENTRAL_DIRECTORY (empty archive)" do
+      subject.begin_central_directory(0)
+      expect(subject.state).to eq(:central_directory)
+    end
+  end
+
+  describe "query methods" do
+    describe "#can_begin_entry?" do
+      it "returns true from states that allow new entries" do
+        expect(subject.can_begin_entry?).to be true
+
+        subject.begin_entry(double("Entry"), 0)
+        subject.begin_entry_body(50)
+        expect(subject.can_begin_entry?).to be true
+
+        subject.write_data_descriptor(100)
+        expect(subject.can_begin_entry?).to be true
+      end
+
+      it "returns false from LOCAL_HEADER" do
+        subject.begin_entry(double("Entry"), 0)
+        expect(subject.can_begin_entry?).to be false
+      end
+
+      it "returns false from CENTRAL_DIRECTORY" do
+        subject.begin_central_directory(0)
+        expect(subject.can_begin_entry?).to be false
+      end
+
+      it "returns false when closed" do
+        subject.begin_central_directory(0)
+        subject.finalize(100)
+        expect(subject.can_begin_entry?).to be false
+      end
+    end
+
+    describe "#can_write_body?" do
+      it "returns true only from ENTRY_BODY" do
+        expect(subject.can_write_body?).to be false
+
+        subject.begin_entry(double("Entry"), 0)
+        expect(subject.can_write_body?).to be false
+
+        subject.begin_entry_body(50)
+        expect(subject.can_write_body?).to be true
+
+        subject.write_data_descriptor(100)
+        expect(subject.can_write_body?).to be false
+      end
+    end
+
+    describe "#can_close_archive?" do
+      it "returns true from states that allow closing" do
+        expect(subject.can_close_archive?).to be true
+
+        subject.begin_entry(double("Entry"), 0)
+        subject.begin_entry_body(50)
+        expect(subject.can_close_archive?).to be true
+
+        subject.write_data_descriptor(100)
+        expect(subject.can_close_archive?).to be true
+      end
+
+      it "returns false from LOCAL_HEADER" do
+        subject.begin_entry(double("Entry"), 0)
+        expect(subject.can_close_archive?).to be false
+      end
+
+      it "returns false from CENTRAL_DIRECTORY" do
+        subject.begin_central_directory(0)
+        expect(subject.can_close_archive?).to be false
+      end
+    end
+
+    describe "#closed?" do
+      it "returns true only after finalize" do
+        expect(subject.closed?).to be false
+
+        subject.begin_central_directory(0)
+        expect(subject.closed?).to be false
+
+        subject.finalize(100)
+        expect(subject.closed?).to be true
+      end
+    end
+
+    describe "#in_entry?" do
+      it "returns true from LOCAL_HEADER and ENTRY_BODY" do
+        expect(subject.in_entry?).to be false
+
+        subject.begin_entry(double("Entry"), 0)
+        expect(subject.in_entry?).to be true
+
+        subject.begin_entry_body(50)
+        expect(subject.in_entry?).to be true
+
+        subject.write_data_descriptor(100)
+        expect(subject.in_entry?).to be false
+      end
+    end
+  end
+end


### PR DESCRIPTION
We have a number of things which may only occur on state transitions or in certain states - where the states are defined by the section of the ZIP file we have just output. It is better - for rollbacks, but also for general sanity - to control this via a state machine instead of flags.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce a state machine to track ZIP output state in `ZipKit::Streamer`, enforce valid call sequences (with new `InvalidState` errors), and refine rollback behavior; add comprehensive tests.
> 
> - **Core**:
>   - Add `ZipKit::Streamer::StateMachine` to track states (`initial`, `local_header`, `entry_body`, `data_descriptors`, `central_directory`, `end_of_central_directory`) and validate transitions.
>   - Expose `state_machine` on `ZipKit::Streamer`; raise `InvalidState` on invalid operations (e.g., adding entries after close, re-closing).
>   - Integrate state transitions in `add_file_and_write_local_header`, `update_last_entry_and_write_data_descriptor`, and `close` (begin central directory, finalize).
>   - Add guards `raise_if_cannot_begin_entry!` and `raise_if_closed!` to enforce sequencing.
>   - Rework `rollback!` to consult state machine, remove failed entry, rebuild `@path_set`, and add `Filler` based on bytes written.
> - **Tests**:
>   - New `spec/zip_kit/streamer/state_machine_spec.rb` covering transitions, queries, rollback, and finalization.
>   - Extend `spec/zip_kit/streamer_spec.rb` to assert sequencing errors, state tracking through heuristics, rollback behavior, and valid multi-entry flows.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebb1940c8ebdd26c64ab65f9f0b5d82c187d2265. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->